### PR TITLE
feat(board): add board model, routes, and controllers for CRUD operations

### DIFF
--- a/backend/src/controllers/boardController.ts
+++ b/backend/src/controllers/boardController.ts
@@ -1,0 +1,105 @@
+import { Request, Response } from "express";
+import Board from "../models/Board";
+import Project from "../models/Project";
+import { AuthRequest } from "../middlewares/authMiddleware";
+import mongoose from "mongoose";
+
+// Create a new board inside a project
+export const createBoard = async (req: AuthRequest, res: Response) => {
+  try {
+    const { id: projectId } = req.params;
+    const { name } = req.body;
+    const userId = req.user.id;
+
+    if (!name) return res.status(400).json({ msg: "Board name is required" });
+
+    const project = await Project.findOne({ _id: projectId, "members.userId": userId });
+    if (!project) return res.status(403).json({ msg: "Not authorized or project not found" });
+
+    const defaultColumns = [
+      { id: "todo", title: "To Do", order: 1 },
+      { id: "inprogress", title: "In Progress", order: 2 },
+      { id: "done", title: "Done", order: 3 },
+    ];
+
+    const board = new Board({
+      name,
+      projectId: new mongoose.Types.ObjectId(projectId),
+      columns: defaultColumns,
+    });
+
+    await board.save();
+    res.status(201).json(board);
+  } catch (err) {
+    res.status(500).json({ msg: (err as Error).message });
+  }
+};
+
+// Get all boards for a project
+export const getProjectBoards = async (req: AuthRequest, res: Response) => {
+  try {
+    const { id: projectId } = req.params;
+    const userId = req.user.id;
+
+    const project = await Project.findOne({ _id: projectId, "members.userId": userId });
+    if (!project) return res.status(403).json({ msg: "Not authorized or project not found" });
+
+    const boards = await Board.find({ projectId });
+    res.json(boards);
+  } catch (err) {
+    res.status(500).json({ msg: (err as Error).message });
+  }
+};
+
+// Update board columns (rename, reorder, etc.)
+export const updateBoardColumns = async (req: AuthRequest, res: Response) => {
+  try {
+    const { boardId } = req.params;
+    const { columns } = req.body; // array of { id, title, order }
+
+    if (!columns || !Array.isArray(columns))
+      return res.status(400).json({ msg: "Columns array is required" });
+
+    const userId = req.user.id;
+    const board = await Board.findById(boardId);
+    if (!board) return res.status(404).json({ msg: "Board not found" });
+
+    const project = await Project.findOne({
+      _id: board.projectId,
+      "members.userId": userId,
+    });
+    if (!project) return res.status(403).json({ msg: "Not authorized" });
+
+    board.columns = columns;
+    await board.save();
+
+    res.json({ msg: "Board columns updated", board });
+  } catch (err) {
+    res.status(500).json({ msg: (err as Error).message });
+  }
+};
+
+// Delete a board
+export const deleteBoard = async (req: AuthRequest, res: Response) => {
+  try {
+    const { boardId } = req.params;
+    const userId = req.user.id;
+
+    const board = await Board.findById(boardId);
+    if (!board) return res.status(404).json({ msg: "Board not found" });
+
+
+    const project = await Project.findOne({
+      _id: board.projectId,
+      "members.userId": userId,
+    });
+    if (!project) return res.status(403).json({ msg: "Not authorized" });
+
+    await Board.findByIdAndDelete(boardId);
+    res.json({ msg: "Board deleted successfully" });
+  } catch (err) {
+    res.status(500).json({ msg: (err as Error).message });
+  }
+};
+
+

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import connectDB from "./config/db";
 import authRoutes from "./routes/authRoutes";
 import profileRoutes from "./routes/profileRoutes"
 import projectRoutes from "./routes/projectRoutes"
+import boardRoutes from "./routes/boardRoutes";
 import { createServer } from "http";
 import { Server } from "socket.io";
 import cookieParser from "cookie-parser";
@@ -28,6 +29,7 @@ app.use(express.json());
 app.use("/api/auth", authRoutes);
 app.use("/api/profile", profileRoutes);
 app.use("/api/projects", projectRoutes);
+app.use("/api/projects", boardRoutes);
 
 const PORT = process.env.PORT || 5000;
 

--- a/backend/src/models/Board.ts
+++ b/backend/src/models/Board.ts
@@ -1,0 +1,35 @@
+import mongoose, { Document, Schema } from "mongoose";
+
+export interface IColumn {
+  id: string;          
+  title: string;       
+  order: number;     
+}
+
+export interface IBoard extends Document {
+  name: string;
+  projectId: mongoose.Types.ObjectId;
+  columns: IColumn[];
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+const columnSchema = new Schema<IColumn>(
+  {
+    id: { type: String, required: true },
+    title: { type: String, required: true },
+    order: { type: Number, required: true },
+  },
+  { _id: false }
+);
+
+const boardSchema = new Schema<IBoard>(
+  {
+    name: { type: String, required: true },
+    projectId: { type: mongoose.Schema.Types.ObjectId, ref: "Project", required: true },
+    columns: { type: [columnSchema], default: [] },
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model<IBoard>("Board", boardSchema);

--- a/backend/src/routes/boardRoutes.ts
+++ b/backend/src/routes/boardRoutes.ts
@@ -1,0 +1,13 @@
+import express from "express";
+import { authMiddleware } from "../middlewares/authMiddleware";
+import { createBoard, getProjectBoards,updateBoardColumns,deleteBoard } from "../controllers/boardController";
+
+const router = express.Router();
+
+router.post("/:id/boards", authMiddleware, createBoard);
+router.get("/:id/boards", authMiddleware, getProjectBoards);
+router.put("/boards/:boardId/columns", authMiddleware, updateBoardColumns);
+router.delete("/boards/:boardId", authMiddleware, deleteBoard);
+
+
+export default router;


### PR DESCRIPTION
Implements the Board module in TaskSphere. This feature allows users to create, view, update, and delete boards within a project. Each board supports customizable columns for managing Kanban-style workflows.

Added Board model linked to Project
Implemented CRUD endpoints for boards:

- POST /api/projects/:id/boards — Create board
- GET /api/projects/:id/boards — Fetch project boards
- PUT /api/projects/boards/:boardId/columns — Update board columns
- DELETE /api/projects/boards/:boardId — Delete board

Added authorization checks to ensure only project members can modify boards